### PR TITLE
Add new parameterized complexity papers to the Scheduling Zoo

### DIFF
--- a/bib/paramterized_complexity_scheduling_aneesha.bib
+++ b/bib/paramterized_complexity_scheduling_aneesha.bib
@@ -8,9 +8,9 @@
 	year={2024},
 	doi ={https://doi.org/10.1007/s10951-023-00788-4},
 	publisher={Springer},
-	Annote = {$P|\mathcal{M}_j(\text{type});prec;r_j,d_j=d|C_{\max} [\tw;\rho]$ is fixed parameter tractable\\
-			 $P|\mathcal{M}_j(\text{type});prec;r_j;s_l{\max} |C_{\max} [\tw;\rho]$ is fixed parameter tractable
-			 $P|\mathcal{M}_j(\text{type});prec;r_j;s_l{\max} |L_{\max} [\tw;\rho]$ is fixed parameter tractable}
+	Annote = {$P|\mathcal{M}_j(\text{type});prec;r_j,d_j=d|C_{\max} [\pw(I);\rho]$ is fixed parameter tractable\\
+			 $P|\mathcal{M}_j(\text{type});prec;r_j;\lambda_{\max} |C_{\max} [\pw(I);\rho]$ is fixed parameter tractable
+			 $P|\mathcal{M}_j(\text{type});prec;r_j;\lambda{\max} |L_{\max} [\pw(I);\rho]$ is fixed parameter tractable}
 }
 @article{HermelinPinedo:19:On-the-parameterized-tractability-of-single-machine-scheduling-with-rejection,
 	author = {Danny Hermelin and Michael Pinedo and Dvir Shabtay and Nimrod Talmon},
@@ -79,9 +79,9 @@
 	pages={192--200},
 	year={2021},
 	doi ={https://doi.org/10.1609/icaps.v31i1.15962},
-	Annote ={$P|cliques;M_j|\sum C_j [\#b]$ is fixed parameter tractable\\
-			 $R|cliques|\sum w_j C_j [\m;\p_{\max};\vartheta]$ is fixed parameter tractable\\
-			 $R|cliques|\sum w_j C_j [\#b;\p_{\max};\vartheta]$ is fixed parameter tractable}
+	Annote ={$P|cliques;M(k)|\sum C_j [\#b]$ is fixed parameter tractable\\
+			 $R|cliques|\sum w_j C_j [\m;\p_{\max};\#vartheta]$ is fixed parameter tractable\\
+			 $R|cliques|\sum w_j C_j [\#b;\p_{\max};\#vartheta]$ is fixed parameter tractable}
 }
 @article{KaulMnichMolter:24:Single-Machine-Scheduling-to-Minimize-the-Number-of-Tardy-Jobs-with-Release-Dates,
 	title={Single-Machine Scheduling to Minimize the Number of Tardy Jobs with Release Dates}, 
@@ -102,7 +102,7 @@
 	pages = {629-639},
 	year = {2021},
 	doi = {https://doi.org/10.1016/j.ejor.2020.09.042},
-	Annote = {$1|r_j;s_j;d_j=d;rej|\sum w_j T_j [\tw;\lambda]$ is fixed parameter tractable}
+	Annote = {$1|r_j;s_j;d_j=d;\text{reject}|\sum_{j \notin R}w_j T_j-\sum_{j \notin R}v_j [\pw(I);\lambda_{max}]$ is fixed parameter tractable}
 }
 @article{ChenMarxZhang:17:Parameterized-and-approximation-results-for-scheduling-with-a-low-rank-processing-time-matrix,
 	title={Parameterized and approximation results for scheduling with a low rank processing time matrix},
@@ -128,4 +128,21 @@
 			 $1|nr=1|C_{\max} [\#q_{nr};\a_{\max}]$ is fixed parameter tractable under non-idling(NI)\\
 			 $1|nr=r|C_{\max} [\#q_{nr};a_{\max};\#r]$ is fixed parameter tractable\\			 
 			 $1|nr;p_j=1|C_{\max} [u_{\max}]$ is NP-hard and W[1]-hard}
+}
+@article{KnopKoutecký:17:Scheduling-meets-n-fold-integer-programming,
+   title={Scheduling meets n-fold integer programming},
+   volume={21},
+   ISSN={1099-1425},
+   DOI={https://doi.org/10.48550/arXiv.1603.02611},
+   number={5},
+   journal={Journal of Scheduling},
+   publisher={Springer Science and Business Media LLC},
+   author={Knop, Dušan and Koutecký, Martin},
+   year={2017},
+   Annote = {$Q||C_{\max} [p_{\max}]$ is fixed parameter tractable\\
+			 R||C_{\max} [p_{\max};\#K]$ is fixed parameter tractable\\
+			 $R||\sum w_j C_j [\m;\#vartheta]$ is fixed parameter tractable\\
+			 $R||\sum w_j C_j [p_{\max};\w_{\max};\#K]$ is fixed parameter tractable\\
+			 P||Cmax [\m]$ is W[1]-hard\\
+			 P||\sum w_j C_j [\m]$ is W[1]-hard}
 }

--- a/bib/paramterized_complexity_scheduling_aneesha.bib
+++ b/bib/paramterized_complexity_scheduling_aneesha.bib
@@ -20,11 +20,11 @@
 	pages = {67-73},
 	year = {2019},
 	doi = {https://doi.org/10.1016/j.ejor.2018.07.038},
-	Annote = {$1|reject|\sum C_j [\|A|]$ is W[1]-hard\\
-			 $1|reject|\sum C_j [\#p]$ is fixed parameter tractable\\
-			 $1|reject|\sum C_j [\#e]$ is fixed parameter tractable\\
-			 $1|reject|\sum C_j [p_{\max}]$ is fixed parameter tractable\\
-			 $1|reject|\sum C_j [\e_{\max}]$ is fixed parameter tractable}
+	Annote = {$1|rej|\sum C_j [\#acc]$ is W[1]-hard\\
+			 $1|rej|\sum C_j [\#p]$ is fixed parameter tractable\\
+			 $1|rej|\sum C_j [\#e]$ is fixed parameter tractable\\
+			 $1|rej|\sum C_j [p_{\max}]$ is fixed parameter tractable\\
+			 $1|rej|\sum C_j [\e_{\max}]$ is fixed parameter tractable}
 }
 @article{HermelinMnichOmlor:24:Serial-batching-to-minimize-the-weighted-number-of-tardy-jobs,
 	author={Hermelin, Danny and Mnich, Matthias and Omlor, Simon},
@@ -37,8 +37,11 @@
 	doi ={https://doi.org/10.1007/s10951-024-00818-9},
 	publisher={Springer},
 	Annote ={$1|s-batch(\infty);r_j|\sum w_j(1-U_j) [\#p;#d]$ is W[1]-hard\\
-			 $1|s-batch(\infty);r_j|\sum w_j(1-U_j) [\#d;#p;#r]$ is fixed parameter tractable\\
-			 $1|s-batch(\infty);r_j|\sum w_j(1-U_j) [\#d;#w]$ is fixed parameter tractable}
+	         $1|s-batch(\infty);r_j|\sum w_j(1-U_j) [\#p;#r]$ is W[1]-hard
+			 $1|s-batch(\infty)|\sum w_j(1-U_j) [\#d;#p]$ is fixed parameter tractable\\
+			 $1|s-batch(\infty)|\sum w_j(1-U_j) [\#d;#w]$ is fixed parameter tractable\\
+			 $1|s-batch(b)|\sum w_j(1-U_j) [\#d;#w]$ is fixed parameter tractable\\
+			 $1|s-batch(b);r_j|\sum U_j [\#d;#p;#r]$ is fixed parameter tractable}
 }
 @article{YuOron:25:Single-machine-scheduling-with-fixed-energy-recharging-times-to-minimize-the-number-of-late-jobs-and-the-number-of-just-in-time-jobs-A-parameterized-complexity-analysis,
 	author = {Renjie Yu and Daniel Oron},
@@ -51,8 +54,8 @@
 	doi = {https://doi.org/10.1016/j.ejor.2025.01.007},
 	Annote ={$1|ren\text{-}e|\sum 1-U_j is NP-hard when $\#d=\#p=1$\\
 			 $1|ren\text{-}e;p_j=1|\sum w_j [\#d]$ is W[1]-hard\\
-			 $1|ren\text{-}e|\sum 1-U_j [\#e;\#d]$ is fixed parameter tractable\\
-			 $1|ren\text{-}e|\sum w_j [\#e;\#d]$ is fixed parameter tractable}		  
+			 $1|ren\text{-}e|\sum 1-U_j [\#enr;\#d]$ is fixed parameter tractable\\
+			 $1|ren\text{-}e|\sum w_j [\#enr;\#d]$ is fixed parameter tractable}		  
 }
 @article{MallemHanenKordon:24:A-New-Structural-Parameter-on-Single-Machine-Scheduling-with-Release-Dates-and-Deadlines,
 	AUTHOR = {Mallem, Maher and Hanen, Claire C. and Munier-Kordon, Alix},
@@ -67,4 +70,62 @@
 	DOI = {https://doi.org/10.1007/978-3-031-60924-4_16},
 	ANNOTE = {$1|prec;r_j;d_j|C_{\max} [\#q]$ is fixed parameter tractable\\
 			 $1|prec;r_j|L_{\max} [\#q]$ is fixed parameter tractable}
+}
+@article{JansenLassotaMaackPikies:21:Total-completion-time-minimization-for-scheduling-with-incompatibility-cliques,
+	title={Total completion time minimization for scheduling with incompatibility cliques},
+	author={Jansen, Klaus and Lassota, Alexandra and Maack, Marten and Pikies, Tytus},
+	volume={31},
+	pages={192--200},
+	year={2021},
+	doi ={https://doi.org/10.1609/icaps.v31i1.15962},
+	Annote ={$P|cliques;M_j|\sum C_j [\#b]$ is fixed parameter tractable\\
+			 $R|cliques|\sum w_j C_j [\#m;\#p_{\max};\n]$ is fixed parameter tractable\\
+			 $R|cliques|\sum w_j C_j [\#b;\#p_{\max};\#n]$ is fixed parameter tractable}
+}
+@article{KaulMnichMolter:24:Single-Machine-Scheduling-to-Minimize-the-Number-of-Tardy-Jobs-with-Release-Dates,
+	title={Single-Machine Scheduling to Minimize the Number of Tardy Jobs with Release Dates}, 
+	author={Matthias Kaul and Matthias Mnich and Hendrik Molter},
+	year={2024},
+	doi={https://doi.org/10.48550/arXiv.2408.12967},
+	Annote ={$1|r_j|\sum w_j(1-U_j) [\#d;\#r]$ is W[1]-hard even if $\#w=1$\\
+			 $1|r_j|\sum w_j(1-U_j) [\#p;\#d;\#r]$ is fixed parameter tractable\\
+			 $1|r_j|\sum w_j(1-U_j) [\#p;\#w;\#d]$ is fixed parameter tractable\\
+			 $1|r_j|\sum w_j(1-U_j) [\#p;\#w;\#r]$ is fixed parameter tractable}
+}
+@article{WeerdtBaartHe:21:Single-machine-scheduling-with-release-times-deadlines-setup-times-and-rejection,
+	title = {Single-machine scheduling with release times, deadlines, setup times, and rejection},
+	author = {Mathijs {de Weerdt} and Robert Baart and Lei He},
+	journal = {European Journal of Operational Research},
+	volume = {291},
+	number = {2},
+	pages = {629-639},
+	year = {2021},
+	doi = {https://doi.org/10.1016/j.ejor.2020.09.042},
+	Annote = {$1|r_j;s_j;d_j;rej|\sum w_j T_j [\#tw;\lambda]$ is fixed parameter tractable}
+}
+@article{ChenMarxZhang:17:Parameterized-and-approximation-results-for-scheduling-with-a-low-rank-processing-time-matrix,
+	title={Parameterized and approximation results for scheduling with a low rank processing time matrix},
+	author={Chen, Lin and Marx, D{\'a}niel and Ye, Deshi and Zhang, Guochuan},
+	pages={22--1},
+	year={2017},
+	doi={https://doi.org/10.4230/LIPIcs.STACS.2017.22},
+	Annote = {$R||C_{\max} [p_{\max}];\#rk]$ is fixed parameter tractable}
+}
+
+@article{BentertBredereckNiedermeier:23:A-multivariate-complexity-analysis-of-the-material-consumption-scheduling-problem,
+	title={A multivariate complexity analysis of the material consumption scheduling problem},
+	author={Bentert, Matthias and Bredereck, Robert and Gy{\"o}rgyi, P{\'e}ter and Kaczmarczyk, Andrzej and Niedermeier, Rolf},
+	journal={Journal of Scheduling},
+	volume={26},
+	number={4},
+	pages={369--382},
+	year={2023},
+	publisher={Springer},
+	doi={https://doi.org/10.1007/s10951-022-00771-5},
+	Annote = {$1|nr=1;p_j=1|C_{\max} [b_{\max,nr}]$ is para-NP-hard\\
+			 $1|nr=1;p_j=a_j|C_{\max} [\#q_{nr}]$ is W[1]-hard\\
+			 $1|nr=2;p_j=1|C_{\max} [\#q_{nr}]$ is W[1]-hard\\
+			 $1|nr=1|C_{\max} [\#q_{nr};\a_{\max}]$ is fixed parameter tractable under non-idling(NI)\\
+			 $1|nr=r|C_{\max} [\#q_{nr};a_{\max};\#r]$ is fixed parameter tractable\\			 
+			 $1|nr;p_j=1|C_{\max} [u_{\max}]$ is NP-hard and W[1]-hard}
 }

--- a/bib/paramterized_complexity_scheduling_aneesha.bib
+++ b/bib/paramterized_complexity_scheduling_aneesha.bib
@@ -8,7 +8,7 @@
 	year={2024},
 	doi ={https://doi.org/10.1007/s10951-023-00788-4},
 	publisher={Springer},
-	Annote = {$P|\mathcal{M}_j(\text{type});prec;r_j,d_j|C_{\max} [\tw;\rho]$ is fixed parameter tractable\\
+	Annote = {$P|\mathcal{M}_j(\text{type});prec;r_j,d_j=d|C_{\max} [\tw;\rho]$ is fixed parameter tractable\\
 			 $P|\mathcal{M}_j(\text{type});prec;r_j;s_l{\max} |C_{\max} [\tw;\rho]$ is fixed parameter tractable
 			 $P|\mathcal{M}_j(\text{type});prec;r_j;s_l{\max} |L_{\max} [\tw;\rho]$ is fixed parameter tractable}
 }
@@ -69,7 +69,7 @@
 	YEAR = {2024},
 	MONTH = May,
 	DOI = {https://doi.org/10.1007/978-3-031-60924-4_16},
-	ANNOTE = {$1|prec;r_j;d_j|C_{\max} [\#q]$ is fixed parameter tractable\\
+	ANNOTE = {$1|prec;r_j;d_j=d|C_{\max} [\#q]$ is fixed parameter tractable\\
 			 $1|prec;r_j|L_{\max} [\#q]$ is fixed parameter tractable}
 }
 @article{JansenLassotaMaackPikies:21:Total-completion-time-minimization-for-scheduling-with-incompatibility-cliques,
@@ -102,7 +102,7 @@
 	pages = {629-639},
 	year = {2021},
 	doi = {https://doi.org/10.1016/j.ejor.2020.09.042},
-	Annote = {$1|r_j;s_j;d_j;rej|\sum w_j T_j [\tw;\lambda]$ is fixed parameter tractable}
+	Annote = {$1|r_j;s_j;d_j=d;rej|\sum w_j T_j [\tw;\lambda]$ is fixed parameter tractable}
 }
 @article{ChenMarxZhang:17:Parameterized-and-approximation-results-for-scheduling-with-a-low-rank-processing-time-matrix,
 	title={Parameterized and approximation results for scheduling with a low rank processing time matrix},
@@ -110,7 +110,7 @@
 	pages={22--1},
 	year={2017},
 	doi={https://doi.org/10.4230/LIPIcs.STACS.2017.22},
-	Annote = {$R||C_{\max} [p_{\max}];\#rk]$ is fixed parameter tractable}
+	Annote = {$R||C_{\max} [p_{\max}];\rk]$ is fixed parameter tractable}
 }
 @article{BentertBredereckNiedermeier:23:A-multivariate-complexity-analysis-of-the-material-consumption-scheduling-problem,
 	title={A multivariate complexity analysis of the material consumption scheduling problem},

--- a/bib/paramterized_complexity_scheduling_aneesha.bib
+++ b/bib/paramterized_complexity_scheduling_aneesha.bib
@@ -54,3 +54,17 @@
 			 $1|ren\text{-}e|\sum 1-U_j [\#e;\#d]$ is fixed parameter tractable\\
 			 $1|ren\text{-}e|\sum w_j [\#e;\#d]$ is fixed parameter tractable}		  
 }
+@article{MallemHanenKordon:24:A-New-Structural-Parameter-on-Single-Machine-Scheduling-with-Release-Dates-and-Deadlines,
+	AUTHOR = {Mallem, Maher and Hanen, Claire C. and Munier-Kordon, Alix},
+	TITLE = {A New Structural Parameter on Single Machine Scheduling with Release Dates and Deadlines},
+	BOOKTITLE = {{Lecture Notes in Computer Science}},
+	PUBLISHER = {{Springer Nature Switzerland}},
+	SERIES = {Lecture Notes in Computer Science},
+	VOLUME = {14594},
+	PAGES = {205-219},
+	YEAR = {2024},
+	MONTH = May,
+	DOI = {https://doi.org/10.1007/978-3-031-60924-4_16},
+	ANNOTE = {$1|prec;r_j;d_j|C_{\max} [\#q]$ is fixed parameter tractable\\
+			 $1|prec;r_j|L_{\max} [\#q]$ is fixed parameter tractable}
+}

--- a/bib/paramterized_complexity_scheduling_aneesha.bib
+++ b/bib/paramterized_complexity_scheduling_aneesha.bib
@@ -8,8 +8,9 @@
 	year={2024},
 	doi ={https://doi.org/10.1007/s10951-023-00788-4},
 	publisher={Springer},
-	Annote = {$P|M_j;prec;r_j,d_j|C_{\max} [\#tw;#ρ]$ is fixed parameter tractable\\
-			 $P|M_j;prec;r_j;s_l{\max} |L_{\max} [\#tw;#ρ]$ is fixed parameter tractable}
+	Annote = {$P|\mathcal{M}_j(\text{type});prec;r_j,d_j|C_{\max} [\tw;\rho]$ is fixed parameter tractable\\
+			 $P|\mathcal{M}_j(\text{type});prec;r_j;s_l{\max} |C_{\max} [\tw;\rho]$ is fixed parameter tractable
+			 $P|\mathcal{M}_j(\text{type});prec;r_j;s_l{\max} |L_{\max} [\tw;\rho]$ is fixed parameter tractable}
 }
 @article{HermelinPinedo:19:On-the-parameterized-tractability-of-single-machine-scheduling-with-rejection,
 	author = {Danny Hermelin and Michael Pinedo and Dvir Shabtay and Nimrod Talmon},
@@ -20,11 +21,11 @@
 	pages = {67-73},
 	year = {2019},
 	doi = {https://doi.org/10.1016/j.ejor.2018.07.038},
-	Annote = {$1|rej|\sum C_j [\#acc]$ is W[1]-hard\\
-			 $1|rej|\sum C_j [\#p]$ is fixed parameter tractable\\
-			 $1|rej|\sum C_j [\#e]$ is fixed parameter tractable\\
-			 $1|rej|\sum C_j [p_{\max}]$ is fixed parameter tractable\\
-			 $1|rej|\sum C_j [\e_{\max}]$ is fixed parameter tractable}
+	Annote = {$1|e_j \leq R|\sum C_j [\#acc]$ is W[1]-hard\\
+			 $1|e_j \leq R|\sum C_j [\#p]$ is fixed parameter tractable\\
+			 $1|e_j \leq R|\sum C_j [\#e]$ is fixed parameter tractable\\
+			 $1|e_j \leq R|\sum C_j [p_{\max}]$ is fixed parameter tractable\\
+			 $1|e_j \leq R|\sum C_j [\e_{\max}]$ is fixed parameter tractable}
 }
 @article{HermelinMnichOmlor:24:Serial-batching-to-minimize-the-weighted-number-of-tardy-jobs,
 	author={Hermelin, Danny and Mnich, Matthias and Omlor, Simon},
@@ -41,7 +42,7 @@
 			 $1|s-batch(\infty)|\sum w_j(1-U_j) [\#d;#p]$ is fixed parameter tractable\\
 			 $1|s-batch(\infty)|\sum w_j(1-U_j) [\#d;#w]$ is fixed parameter tractable\\
 			 $1|s-batch(b)|\sum w_j(1-U_j) [\#d;#w]$ is fixed parameter tractable\\
-			 $1|s-batch(b);r_j|\sum U_j [\#d;#p;#r]$ is fixed parameter tractable}
+			 $1|s-batch(b);r_j|\sum w_j(1-U_j) [\#d;#p;#r]$ is fixed parameter tractable}
 }
 @article{YuOron:25:Single-machine-scheduling-with-fixed-energy-recharging-times-to-minimize-the-number-of-late-jobs-and-the-number-of-just-in-time-jobs-A-parameterized-complexity-analysis,
 	author = {Renjie Yu and Daniel Oron},
@@ -79,8 +80,8 @@
 	year={2021},
 	doi ={https://doi.org/10.1609/icaps.v31i1.15962},
 	Annote ={$P|cliques;M_j|\sum C_j [\#b]$ is fixed parameter tractable\\
-			 $R|cliques|\sum w_j C_j [\#m;\#p_{\max};\n]$ is fixed parameter tractable\\
-			 $R|cliques|\sum w_j C_j [\#b;\#p_{\max};\#n]$ is fixed parameter tractable}
+			 $R|cliques|\sum w_j C_j [\m;\p_{\max};\vartheta]$ is fixed parameter tractable\\
+			 $R|cliques|\sum w_j C_j [\#b;\p_{\max};\vartheta]$ is fixed parameter tractable}
 }
 @article{KaulMnichMolter:24:Single-Machine-Scheduling-to-Minimize-the-Number-of-Tardy-Jobs-with-Release-Dates,
 	title={Single-Machine Scheduling to Minimize the Number of Tardy Jobs with Release Dates}, 
@@ -101,7 +102,7 @@
 	pages = {629-639},
 	year = {2021},
 	doi = {https://doi.org/10.1016/j.ejor.2020.09.042},
-	Annote = {$1|r_j;s_j;d_j;rej|\sum w_j T_j [\#tw;\lambda]$ is fixed parameter tractable}
+	Annote = {$1|r_j;s_j;d_j;rej|\sum w_j T_j [\tw;\lambda]$ is fixed parameter tractable}
 }
 @article{ChenMarxZhang:17:Parameterized-and-approximation-results-for-scheduling-with-a-low-rank-processing-time-matrix,
 	title={Parameterized and approximation results for scheduling with a low rank processing time matrix},
@@ -111,7 +112,6 @@
 	doi={https://doi.org/10.4230/LIPIcs.STACS.2017.22},
 	Annote = {$R||C_{\max} [p_{\max}];\#rk]$ is fixed parameter tractable}
 }
-
 @article{BentertBredereckNiedermeier:23:A-multivariate-complexity-analysis-of-the-material-consumption-scheduling-problem,
 	title={A multivariate complexity analysis of the material consumption scheduling problem},
 	author={Bentert, Matthias and Bredereck, Robert and Gy{\"o}rgyi, P{\'e}ter and Kaczmarczyk, Andrzej and Niedermeier, Rolf},

--- a/bib/paramterized_complexity_scheduling_aneesha.bib
+++ b/bib/paramterized_complexity_scheduling_aneesha.bib
@@ -1,0 +1,56 @@
+@article{HanenKordonAlix:24:Fixed-parameter-tractability-of-scheduling-dependent-typed-tasks-subject-to-release-times-and-deadlines,
+	author={Hanen, Claire and Munier Kordon, Alix},
+	title={Fixed-parameter tractability of scheduling dependent typed tasks subject to release times and deadlines},
+	journal={Journal of Scheduling},
+	volume={27},
+	number={2},
+	pages={119--133},
+	year={2024},
+	doi ={https://doi.org/10.1007/s10951-023-00788-4},
+	publisher={Springer},
+	Annote = {$P|M_j;prec;r_j,d_j|C_{\max} [\#tw;#ρ]$ is fixed parameter tractable\\
+			 $P|M_j;prec;r_j;s_l{\max} |L_{\max} [\#tw;#ρ]$ is fixed parameter tractable}
+}
+@article{HermelinPinedo:19:On-the-parameterized-tractability-of-single-machine-scheduling-with-rejection,
+	author = {Danny Hermelin and Michael Pinedo and Dvir Shabtay and Nimrod Talmon},
+	title = {On the parameterized tractability of single machine scheduling with rejection},
+	journal = {European Journal of Operational Research},
+	volume = {273},
+	number = {1},
+	pages = {67-73},
+	year = {2019},
+	doi = {https://doi.org/10.1016/j.ejor.2018.07.038},
+	Annote = {$1|reject|\sum C_j [\|A|]$ is W[1]-hard\\
+			 $1|reject|\sum C_j [\#p]$ is fixed parameter tractable\\
+			 $1|reject|\sum C_j [\#e]$ is fixed parameter tractable\\
+			 $1|reject|\sum C_j [p_{\max}]$ is fixed parameter tractable\\
+			 $1|reject|\sum C_j [\e_{\max}]$ is fixed parameter tractable}
+}
+@article{HermelinMnichOmlor:24:Serial-batching-to-minimize-the-weighted-number-of-tardy-jobs,
+	author={Hermelin, Danny and Mnich, Matthias and Omlor, Simon},
+	title={Serial batching to minimize the weighted number of tardy jobs},
+	journal={Journal of Scheduling},
+	volume={27},
+	number={6},
+	pages={545--556},
+	year={2024},
+	doi ={https://doi.org/10.1007/s10951-024-00818-9},
+	publisher={Springer},
+	Annote ={$1|s-batch(\infty);r_j|\sum w_j(1-U_j) [\#p;#d]$ is W[1]-hard\\
+			 $1|s-batch(\infty);r_j|\sum w_j(1-U_j) [\#d;#p;#r]$ is fixed parameter tractable\\
+			 $1|s-batch(\infty);r_j|\sum w_j(1-U_j) [\#d;#w]$ is fixed parameter tractable}
+}
+@article{YuOron:25:Single-machine-scheduling-with-fixed-energy-recharging-times-to-minimize-the-number-of-late-jobs-and-the-number-of-just-in-time-jobs-A-parameterized-complexity-analysis,
+	author = {Renjie Yu and Daniel Oron},
+	title = {Single-machine scheduling with fixed energy recharging times to minimize the number of late jobs and the number of just-in-time jobs: A parameterized complexity analysis},
+	journal = {European Journal of Operational Research},
+	volume = {324},
+	number = {1},
+	pages = {40-48},
+	year = {2025},
+	doi = {https://doi.org/10.1016/j.ejor.2025.01.007},
+	Annote ={$1|ren\text{-}e|\sum 1-U_j is NP-hard when $\#d=\#p=1$\\
+			 $1|ren\text{-}e;p_j=1|\sum w_j [\#d]$ is W[1]-hard\\
+			 $1|ren\text{-}e|\sum 1-U_j [\#e;\#d]$ is fixed parameter tractable\\
+			 $1|ren\text{-}e|\sum w_j [\#e;\#d]$ is fixed parameter tractable}		  
+}


### PR DESCRIPTION
Dear Dr. Dürr,
This pull request adds papers to the Scheduling Zoo under the file parameterized_complexity_scheduling_aneesha.bib as part of my project thesis work.
I would like to mention that, while reviewing some of the papers, I found a few notations and parameters that do not currently seem to be present in the Zoo.
Please let me know if you have any suggestions.

Best Regards.